### PR TITLE
chore: Use Serilog as our integrated logger

### DIFF
--- a/src/Presentation.Server/Presentation.Server.csproj
+++ b/src/Presentation.Server/Presentation.Server.csproj
@@ -16,6 +16,7 @@
     <ProjectReference Include="..\Presentation.Client\Presentation.Client.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.1" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Presentation.Server/Program.cs
+++ b/src/Presentation.Server/Program.cs
@@ -1,10 +1,14 @@
 using Presentation.Server.Components;
+using Serilog;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents()
     .AddInteractiveWebAssemblyComponents();
+
+builder.Host.UseSerilog((_, loggerConfiguration) =>
+    loggerConfiguration.ReadFrom.Configuration(builder.Configuration));
 
 var app = builder.Build();
 
@@ -17,6 +21,8 @@ else
     app.UseExceptionHandler("/Error", createScopeForErrors: true);
     app.UseHsts();
 }
+
+app.UseSerilogRequestLogging();
 
 app.UseHttpsRedirection();
 

--- a/src/Presentation.Server/appsettings.Development.json
+++ b/src/Presentation.Server/appsettings.Development.json
@@ -1,8 +1,17 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+    "Serilog": {
+        "Using": [],
+        "MinimumLevel": {
+            "Default": "Information",
+            "Override": {
+                "Microsoft": "Information",
+                "System": "Information"
+            }
+        },
+        "WriteTo": [
+            {
+                "Name": "Console"
+            }
+        ]
     }
-  }
 }

--- a/src/Presentation.Server/appsettings.json
+++ b/src/Presentation.Server/appsettings.json
@@ -1,9 +1,18 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
-  },
-  "AllowedHosts": "*"
+    "Serilog": {
+        "Using": [],
+        "MinimumLevel": {
+            "Default": "Information",
+            "Override": {
+                "Microsoft": "Warning",
+                "System": "Warning"
+            }
+        },
+        "WriteTo": [
+            {
+                "Name": "Console"
+            }
+        ]
+    },
+    "AllowedHosts": "*"
 }


### PR DESCRIPTION
We want to use serilog as it is a lot more extensiable than the built in logging.

This will also allow us to log to a distributed logging storage (like ELK) easier in the future.